### PR TITLE
add decode_len and decode_len_unsafe and update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 /.idea
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "varint-simd"
 version = "0.4.0"
 authors = ["Andrew Sun <me@andrewsun.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "SIMD-accelerated varint encoder and decoder"
 repository = "https://github.com/as-com/varint-simd"
@@ -23,14 +23,14 @@ native-optimizations = []
 dangerously-force-enable-pdep-since-i-really-know-what-im-doing = []
 
 [dev-dependencies]
-criterion = "0.3"
-integer-encoding = "2.1"
+criterion = "0.5"
+integer-encoding = "4.0"
 rand = "0.8"
 bytes = "1" # prost-varint
 lazy_static = "1.4.0"
 
 [build-dependencies]
-rustc_version = "0.3.0"
+rustc_version = "0.4.0"
 
 [[bench]]
 name = "varint_bench"

--- a/benches/varint_bench/main.rs
+++ b/benches/varint_bench/main.rs
@@ -468,11 +468,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     });
 
     group.bench_function("varint-simd", |b| {
-        b.iter_batched(
-            || rng.gen::<u16>(),
-            encode,
-            BatchSize::SmallInput,
-        )
+        b.iter_batched(|| rng.gen::<u16>(), encode, BatchSize::SmallInput)
     });
     group.finish();
 
@@ -565,11 +561,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     });
 
     group.bench_function("varint-simd", |b| {
-        b.iter_batched(
-            || rng.gen::<u32>(),
-            encode,
-            BatchSize::SmallInput,
-        )
+        b.iter_batched(|| rng.gen::<u32>(), encode, BatchSize::SmallInput)
     });
     group.finish();
 
@@ -663,11 +655,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     });
 
     group.bench_function("varint-simd", |b| {
-        b.iter_batched(
-            || rng.gen::<u64>(),
-            encode,
-            BatchSize::SmallInput,
-        )
+        b.iter_batched(|| rng.gen::<u64>(), encode, BatchSize::SmallInput)
     });
     group.finish();
 }

--- a/benches/varint_bench/main.rs
+++ b/benches/varint_bench/main.rs
@@ -76,7 +76,7 @@ fn decode_batched_varint_simd_unsafe<T: VarIntTarget, const C: usize>(
         // SAFETY: the input slice should have at least 16 bytes of allocated padding at the end
         let (num, len) = unsafe { decode_unsafe::<T>(slice.as_ptr()) };
         out[i] = num;
-        slice = &slice[(len as usize)..];
+        slice = &slice[len..];
     }
 }
 
@@ -153,7 +153,7 @@ fn decode_batched_varint_simd_safe<T: VarIntTarget, const C: usize>(input: &mut 
     for i in 0..C {
         let (num, len) = decode::<T>(slice).unwrap();
         out[i] = num;
-        slice = &slice[(len as usize)..];
+        slice = &slice[len..];
     }
 }
 
@@ -366,7 +366,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     });
 
     group.bench_function("varint-simd", |b| {
-        b.iter_batched(|| rng.gen::<u8>(), |num| encode(num), BatchSize::SmallInput)
+        b.iter_batched(|| rng.gen::<u8>(), encode, BatchSize::SmallInput)
     });
     group.finish();
 
@@ -470,7 +470,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     group.bench_function("varint-simd", |b| {
         b.iter_batched(
             || rng.gen::<u16>(),
-            |num| encode(num),
+            encode,
             BatchSize::SmallInput,
         )
     });
@@ -567,7 +567,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     group.bench_function("varint-simd", |b| {
         b.iter_batched(
             || rng.gen::<u32>(),
-            |num| encode(num),
+            encode,
             BatchSize::SmallInput,
         )
     });
@@ -656,7 +656,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             || rng.gen::<u64>(),
             |num| {
                 target.clear();
-                prost_varint::encode_varint(num as u64, &mut target)
+                prost_varint::encode_varint(num, &mut target)
             },
             BatchSize::SmallInput,
         )
@@ -665,7 +665,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     group.bench_function("varint-simd", |b| {
         b.iter_batched(
             || rng.gen::<u64>(),
-            |num| encode(num),
+            encode,
             BatchSize::SmallInput,
         )
     });

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -32,3 +32,9 @@ name = "fuzz_target_2"
 path = "fuzz_targets/fuzz_target_2.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "fuzz_target_3"
+path = "fuzz_targets/fuzz_target_3.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fuzz_target_3.rs
+++ b/fuzz/fuzz_targets/fuzz_target_3.rs
@@ -1,0 +1,14 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use integer_encoding::VarInt;
+
+fuzz_target!(|data: [u8; 16]| {
+    let reference = u64::decode_var(&data);
+
+    let len = unsafe { varint_simd::decode_len_unsafe::<u64>(data.as_ptr()) };
+
+    if let Some(reference) = reference {
+        assert_eq!(reference.1, len);
+    }
+});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,8 @@ mod tests {
     #[cfg(target_feature = "avx2")]
     use crate::decode_two_wide_unsafe;
     use crate::{
-        decode, decode_eight_u8_unsafe, decode_four_unsafe, decode_two_unsafe, encode,
-        encode_to_slice, VarIntTarget,
+        decode, decode_len, decode_eight_u8_unsafe, decode_four_unsafe, decode_two_unsafe, encode,
+        encode_to_slice, VarIntTarget
     };
 
     use lazy_static::lazy_static;
@@ -79,6 +79,9 @@ mod tests {
         let roundtrip: (T, usize) = decode(&expected).unwrap();
         assert_eq!(roundtrip.0, value);
         assert_eq!(roundtrip.1 as usize, encoded.len());
+
+        let len = decode_len::<T>(&expected).unwrap();
+        assert_eq!(len, encoded.len());
     }
 
     // Test cases borrowed from prost

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,8 @@ mod tests {
     #[cfg(target_feature = "avx2")]
     use crate::decode_two_wide_unsafe;
     use crate::{
-        decode, decode_len, decode_eight_u8_unsafe, decode_four_unsafe, decode_two_unsafe, encode,
-        encode_to_slice, VarIntTarget
+        decode, decode_eight_u8_unsafe, decode_four_unsafe, decode_len, decode_two_unsafe, encode,
+        encode_to_slice, VarIntTarget,
     };
 
     use lazy_static::lazy_static;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ impl std::error::Error for VarIntDecodeError {}
 
 #[cfg(test)]
 mod tests {
-    #[cfg(any(target_feature = "avx2"))]
+    #[cfg(target_feature = "avx2")]
     use crate::decode_two_wide_unsafe;
     use crate::{
         decode, decode_eight_u8_unsafe, decode_four_unsafe, decode_two_unsafe, encode,
@@ -222,7 +222,7 @@ mod tests {
         }
     }
 
-    #[cfg(any(target_feature = "avx2"))]
+    #[cfg(target_feature = "avx2")]
     fn check_decode_wide_2x<T: VarIntTarget, U: VarIntTarget>(a: &[T], b: &[U]) {
         for i in a {
             for j in b {
@@ -271,7 +271,7 @@ mod tests {
                         assert_eq!(decoded.5, second_len);
                         assert_eq!(decoded.6, third_len);
                         assert_eq!(decoded.7, fourth_len);
-                        assert_eq!(decoded.8, false);
+                        assert!(!decoded.8);
                     }
                 }
             }
@@ -345,7 +345,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_feature = "avx2"))]
+    #[cfg(target_feature = "avx2")]
     fn test_decode_2x_wide_u8_x() {
         check_decode_wide_2x::<u8, u8>(&NUMS_U8[..], &NUMS_U8[..]);
         check_decode_wide_2x::<u8, u16>(&NUMS_U8[..], &NUMS_U16[..]);
@@ -362,7 +362,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_feature = "avx2"))]
+    #[cfg(target_feature = "avx2")]
     fn test_decode_2x_wide_u16_x() {
         check_decode_wide_2x::<u16, u8>(&NUMS_U16[..], &NUMS_U8[..]);
         check_decode_wide_2x::<u16, u16>(&NUMS_U16[..], &NUMS_U16[..]);
@@ -379,7 +379,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_feature = "avx2"))]
+    #[cfg(target_feature = "avx2")]
     fn test_decode_2x_wide_u32_x() {
         check_decode_wide_2x::<u32, u8>(&NUMS_U32[..], &NUMS_U8[..]);
         check_decode_wide_2x::<u32, u16>(&NUMS_U32[..], &NUMS_U16[..]);
@@ -396,7 +396,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_feature = "avx2"))]
+    #[cfg(target_feature = "avx2")]
     fn test_decode_2x_wide_u64_x() {
         check_decode_wide_2x::<u64, u8>(&NUMS_U64[..], &NUMS_U8[..]);
         check_decode_wide_2x::<u64, u16>(&NUMS_U64[..], &NUMS_U16[..]);


### PR DESCRIPTION
As the title says. Adds `decode_len` and `decode_len_unsafe` to only get the length of the next varint in a slice. This can be used to faster find a given number in a buffer of encoded varints.