### PR TITLE
Fix pdep_speed return type for non x86 arch

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -50,7 +50,7 @@ fn pdep_speed() -> PdepPerf {
 }
 
 #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
-fn pdep_speed() -> bool {
+fn pdep_speed() -> PdepPerf {
     PdepPerf::Slow
 }
 


### PR DESCRIPTION
hi! this change was missed in https://github.com/as-com/varint-simd/commit/f4c4af672403cc68391ee5dd1d9eb478ce410c8a