### PR TITLE
Derive more traits for `VarIntDecodeError`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ fn slice_m256i(n: __m256i) -> [i8; 32] {
     unsafe { core::mem::transmute(n) }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum VarIntDecodeError {
     Overflow,
     NotEnoughBytes,


### PR DESCRIPTION
This allows types wrapping `VarIntDecodeError` to derive those traits.